### PR TITLE
ci(check-link): não validar link de e-mail

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -11,6 +11,9 @@
 		},
 		{
 			"pattern": "https://codecov.io/gh/PauloGoncalvesBH/ServeRest"
+		},
+		{
+			"pattern": "mailto:"
 		}
 	],
 	"replacementPatterns": [


### PR DESCRIPTION
`mailto:` está quebrando na validação de links, embora esteja funcionando corretamente.

Deve ser alguma implementação nova do github que ofusca os e-mails para bots.