### PR TITLE
fix(montarMensagemDeErroDeSchema): traduzir 'string.empty'

### DIFF
--- a/src/utils/montarMensagemDeErroDeSchema.js
+++ b/src/utils/montarMensagemDeErroDeSchema.js
@@ -8,6 +8,7 @@ module.exports = error => {
     const mapeamentoDoErro = {
       'any.required': `${propriedade} é obrigatório`,
       'string.email': `${propriedade} deve ser um email válido`,
+      'string.empty': `${propriedade} não pode ficar em branco`,
       'string.base': `${propriedade} deve ser uma string`,
       'object.unknown': `${propriedade} não é permitido`,
       'array.includesRequiredUnknowns': `${propriedade} não contém 1 valor obrigatório`,

--- a/test/login/post.test.js
+++ b/test/login/post.test.js
@@ -44,4 +44,13 @@ describe(rotaLogin + ' POST', () => {
       password: 'password é obrigatório'
     })
   })
+
+  it('Bad request - Email em branco', async () => {
+    const { body } = await request.post(rotaLogin).send({ email: '' }).expect(400)
+
+    chai.assert.deepEqual(body, {
+      email: 'email não pode ficar em branco',
+      password: 'password é obrigatório'
+    })
+  })
 })


### PR DESCRIPTION
fix #109 