### PR TITLE
Adiciona a seção de apoio e badge do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,17 @@ Utilize esse comportamento nos seus testes, validando a presença/ausência dess
 
 > Para saber mais leia o [checklist de segurança de API](https://github.com/shieldfy/API-Security-Checklist#api-security-checklist)
 
+
 ## Demonstre seu apoio ao ServeRest
 
 Adicione ao README.md do seu repositório o badge do Serverest e demonstre seu apoio ao projeto.
 
-[![ServeRest API](https://img.shields.io/badge/ServeRest-API-green?style=for-the-badge)](https://serverest.js.org/)
+[![ServeRest API](https://img.shields.io/badge/API-ServeRest-green?style=for-the-badge)](https://serverest.js.org/)
+
 ```markdown
-[![ServeRest API](https://img.shields.io/badge/ServeRest-API-green?style=for-the-badge)](https://serverest.js.org/)
+[![ServeRest API](https://img.shields.io/badge/API-ServeRest--green?style=for-the-badge)](https://serverest.js.org/)
 ```
+
 
 ## Empresas que utilizam o ServeRest
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Por default, o _ServeRest_ irá fazer as seguintes alterações no cabeçalho, q
 Utilize esse comportamento nos seus testes, validando a presença/ausência desses cabeçalhos.
 
 > Para saber mais leia o [checklist de segurança de API](https://github.com/shieldfy/API-Security-Checklist#api-security-checklist)
+
 ## Demonstre seu apoio ao ServeRest
 
 Adicione ao README.md do seu repositório o badge do Serverest e demonstre seu apoio ao projeto.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Adicione ao README.md do seu repositório o badge do Serverest e demonstre seu a
 [![ServeRest API](https://img.shields.io/badge/API-ServeRest-green?style=for-the-badge)](https://serverest.js.org/)
 
 ```markdown
-[![ServeRest API](https://img.shields.io/badge/API-ServeRest--green?style=for-the-badge)](https://serverest.js.org/)
+[![ServeRest API](https://img.shields.io/badge/API-ServeRest-green?style=for-the-badge)](https://serverest.js.org/)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Adicione ao README.md do seu repositório o badge do Serverest e demonstre seu a
 ```markdown
 [![ServeRest API](https://img.shields.io/badge/ServeRest-API-green?style=for-the-badge)](https://serverest.js.org/)
 ```
+
 ## Empresas que utilizam o ServeRest
 
 <table>

--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ Por default, o _ServeRest_ irá fazer as seguintes alterações no cabeçalho, q
 Utilize esse comportamento nos seus testes, validando a presença/ausência desses cabeçalhos.
 
 > Para saber mais leia o [checklist de segurança de API](https://github.com/shieldfy/API-Security-Checklist#api-security-checklist)
+## Demonstre seu apoio ao ServeRest
 
+Adicione ao README.md do seu repositório o badge do Serverest e demonstre seu apoio ao projeto.
+
+[![ServeRest API](https://img.shields.io/badge/ServeRest-API-green?style=for-the-badge)](https://serverest.js.org/)
+```markdown
+[![ServeRest API](https://img.shields.io/badge/ServeRest-API-green?style=for-the-badge)](https://serverest.js.org/)
+```
 ## Empresas que utilizam o ServeRest
 
 <table>


### PR DESCRIPTION
## Description

Criada a seção de apoio ao projeto incluindo a Badge e o código em Markdown na seção

### How can the user experience this change?

Na seção "Demonstre seu apoio ao ServeRest" podem ser vistas a Badge e Código em Markdown para ser copiado

### Documentation

Não aplicável

## Related Issues
Fixes #121 

## PR Tasks

- [x] Has been related to an issue?
- [ ] Have tests been added/updated?
- [ ] Has Aglio documentation been added/updated?
