### PR TITLE
ci: esses workflows precisam rodar em prs

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 15,21 * * *"
   workflow_dispatch:
   push:
+  pull_request:
 
 jobs:
   check-link:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 21 */14 * *'
+  pull_request:
 
 jobs:
   analyse:

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -3,6 +3,7 @@ name: Mutation Test
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 jobs:
   test-mutation:


### PR DESCRIPTION
## Description

Atender a demanda da issue #131 que precisa que os PRs de terceiros sejam avaliados, pois como hoje está apenas por push, colaboradores externos ao projeto não podem enviar evento de push, dessa forma os workflows não são ativados nesses PRs.

### How can the user experience this change?

N/A

### Documentation

N/A

## Related Issues

#131 

## PR Tasks

N/A