### PR TITLE
fix(docker): habilitar monitoramento

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "commit": "git-cz",
-    "start": "cross-env NODE_ENV=serverest-development node ./src/server.js",
+    "start": "node ./src/server.js",
     "dev": "cross-env NODE_ENV=serverest-development nodemon ./src/server.js --nodoc",
     "test:mutation": "stryker run ./test/stryker.conf.js",
     "test": "cross-env NODE_ENV=serverest-test nyc mocha --config test/.mocharc.js",


### PR DESCRIPTION
O docker utiliza o comando 'npm start' e nele estava desabilitado o uso do monitoramento fornecido pelo moesif.com

<!--
  Have any questions? Check out the contributing docs at https://github.com/PauloGoncalvesBH/ServeRest/blob/trunk/.github/CONTRIBUTING.md :)
-->

## Description

<!-- Write a brief explanation to everyone who's going to read this pull request. -->

### How can the user experience this change?

<!--
  Describe here how to reproduce the changes made. A way to do this is by writing a step by step guide.

  e.g.
  # Create a new user;
  # Get the bearer token authenticating the previously created user;
  ...
-->

### Documentation

<!--
  Where is this API documented? Check out our documentation at https://serverest.js.org/

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create documentation using the existing one as a reference. A guide on how to create the documentation can be found on https://github.com/PauloGoncalvesBH/ServeRest/blob/trunk/.github/CONTRIBUTING.md#documenta%C3%A7%C3%A3o-api-doc
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

## PR Tasks

- [ ] Has been related to an issue?
- [ ] Have tests been added/updated?
- [ ] Has Aglio documentation been added/updated?
