### PR TITLE
fix(docker): change node image to alpine image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .git
 .github
-.ny_output
+.nyc_output
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
 .git
 .github
 .nyc_output
+docs/
+test/
+reports/
+CHANGELOG.md
+.stryker-tmp
+stryker.log
+coverage.lcov
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+.ny_output
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:lts-alpine3.12
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://github.com/PauloGoncalvesBH/ServeRest/blob/trunk/.github/CONTRIBUTING.md :)
-->

## Description

I download the image com docker hub an check the image is too large. 
I changed to node:alpine image to reduce the size.
Check the attached image to see de diference

![Screenshot from 2020-10-05 10-00-17](https://user-images.githubusercontent.com/29265526/95105938-38dee380-070e-11eb-969b-d99c11af5d21.png)


### How can the user experience this change?

Run the command
`docker pull paulogoncalvesbh/serverest:latest`

after:

`docker images`  and check the image size.

### Documentation

It is not necessary.

## Related Issues

No.

## PR Tasks

- [ ] Has been related to an issue?
- [ ] Have tests been added/updated?
- [ ] Has Aglio documentation been added/updated?
