### PR TITLE
fix(docker): habilitar acesso à documentação das rotas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .github
 .nyc_output
-docs/
 test/
 reports/
 CHANGELOG.md


### PR DESCRIPTION
O diretório contendo a documentação estava marcado para não fazer parte do container, dando erro ao acessar a rota /

fix #202