### PR TITLE
chore(patch): remover artefato do NPM do container docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .github
 .nyc_output
+dist/
 test/
 reports/
 CHANGELOG.md


### PR DESCRIPTION
Na pipeline de entrega contínua está sendo gerado o artefato do NPM dentro do diretório dist/, e
esse diretório está fazendo parte do container docker gerado logo em seguida. Para evitar que o
artefato faça parte do container ele foi incluído no .dockerignore.