### PR TITLE
feat(rate-limit): interceptar requests de testes de carga para não enviar os dados para o moesif

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ Você pode encontrar as versões disponíveis na [lista de tags no Docker Hub](h
 
 ## Teste de carga
 
-Para utilizar o ServeRest para estudo de teste de carga, sem gerar impacto, é preciso utilizar o header `monitor: false`.
-
 Para acompanhar o comportamento do ambiente aonde o ServeRest está hospedado você pode acessar a página https://serverest.dev/status, pois contém informações como:
 
 - Uso de CPU.
 - Uso da memória.
 - Tempo de resposta.
 - RPS (Requisições por segundo).
+
+> Fez teste de carga? O que acha de compartilhar com o autor do projeto o relatório final contendo dados de RPS para auxiliar o ServeRest a entender o comportamento de sua infra?
 
 ## Badge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "morgan": "^1.10.0",
         "nedb-promises": "^5.0.0",
         "open": "^8.0.6",
+        "rate-limiter-flexible": "^2.3.1",
         "swagger-ui-express": "^4.1.4",
         "yargs": "^16.2.0"
       },
@@ -15812,6 +15813,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.3.1.tgz",
+      "integrity": "sha512-u4Ual0ssf/RHHxK3rqKo9W2S7ulVoNdCAOrsk1gR9JLtzqg7fGw+yaCeyBAEncsL2n6XqHh/0qJk3BPDn49BjA=="
     },
     "node_modules/raw-body": {
       "version": "2.4.0",
@@ -31688,6 +31694,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "rate-limiter-flexible": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.3.1.tgz",
+      "integrity": "sha512-u4Ual0ssf/RHHxK3rqKo9W2S7ulVoNdCAOrsk1gR9JLtzqg7fGw+yaCeyBAEncsL2n6XqHh/0qJk3BPDn49BjA=="
     },
     "raw-body": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "morgan": "^1.10.0",
     "nedb-promises": "^5.0.0",
     "open": "^8.0.6",
+    "rate-limiter-flexible": "^2.3.1",
     "swagger-ui-express": "^4.1.4",
     "yargs": "^16.2.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ const errorHandler = require('./middlewares/error-handler')
 const logger = require('./utils/logger')
 const { version } = require('../package.json')
 const swaggerDocument = require('../docs/swagger.json')
+const rateLimiter = require('./middlewares/rate-limiter')
 
 const ehAmbienteDeTestes = process.env.NODE_ENV === 'serverest-test'
 
@@ -27,6 +28,7 @@ app.use(express.urlencoded({ extended: false }))
 app.use(queryParser())
 app.use(timeout())
 app.use(cors())
+app.use(rateLimiter)
 
 app.disable('etag')
 
@@ -85,7 +87,7 @@ app.use('/produtos', require('./routes/produtos-route'))
 app.use('/carrinhos', require('./routes/carrinhos-route'))
 
 app.use(errorHandler)
-app.use(async (req, res) => {
+app.use((req, res) => {
   res.status(405).send({
     message: `Não é possível realizar ${req.method} em ${req.url}. Acesse ${urlDocumentacao()} para ver as rotas disponíveis e como utilizá-las.`
   })

--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+
+const { RateLimiterMemory } = require('rate-limiter-flexible')
+
+const rateLimiter = new RateLimiterMemory({
+  points: 150, // requests
+  duration: 1 // segundo por IP
+})
+
+// Adicionar header 'monitor: false' quando atingir o limite definido para não enviar informações para o moesif.
+module.exports = async (req, res, next) => {
+  await rateLimiter.consume(req.ip)
+    .then(() => next())
+    .catch(() => {
+      req.headers.monitor = false
+      next()
+    })
+}


### PR DESCRIPTION
O plano utilizado do moesif permite apenas 750 mil requests por mês, caso seja feito mais requests
que esse valor o acesso é bloqueado até o próximo mês. Com essa implementação é esperado que toda
request com comportamento de teste de carga (usuário fazendo mais de 150 RPS) seja interceptada e
impedida de ser enviada para a ferramenta de monitoramento.

Ainda será possível fazer teste de carga, para o usuário nada irá mudar,
é uma alteração que visa apenas garantir que acesso ao monitoramento das
requests que são realizadas não seja perdido.

Também não precisará ter a preocupação de incluir o header 'monitor:
false'.

## Importante

Como o acesso ao moesif foi perdido até o dia 04/11 devido a terem efetuado mais de 1 milhão e 100 mil requests no mês de outubro até o dia 23/10, essa entrega será adiada.
Será entregue apenas no dia 03/11 pois o acesso à ferramenta de monitoramento retornará no dia 04/11, e com isso poderei entender se não gerou nenhum impacto para os usuários.