### PR TITLE
chore(patch): exibir nome de apoiador financeiro de forma randômica no o terminal em agradecimento

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.24.2",
       "license": "GPL-3.0",
       "dependencies": {
+        "axios": "^0.19.2",
         "colors": "^1.4.0",
         "connect-timeout": "^1.9.0",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:contract": "mocha test/contract --timeout 60000"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "colors": "^1.4.0",
     "connect-timeout": "^1.9.0",
     "cors": "^2.8.5",

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,8 @@ const open = require('open')
 const { version } = require('../package.json')
 const { formaDeExecucao, urlDocumentacao } = require('./utils/ambiente')
 const { conf } = require('./utils/conf')
+const getRandomFinancialContributor = require('./utils/getRandomFinancialContributor')
+
 const DEFAULT_PORT = 3000
 
 const argv = require('yargs')
@@ -71,8 +73,8 @@ server.listen(port, async () => {
   } else if (formaDeExecucao() === 'docker') {
     console.log(colors.white.bold('Quer alterar porta de execução, timeout do token, etc? Execute'), colors.yellow.bold('docker run -p 3000:3000 paulogoncalvesbh/serverest --help'))
   }
-  console.log(colors.white.bold('Para outras dúvidas acesse'), colors.yellow.bold('https://github.com/ServeRest/ServeRest'))
-  console.log(colors.cyan.bold('Feito com'), colors.red.bold('♥'), colors.cyan.bold('para todos os QAs\n'))
+  console.log(colors.white.bold('Para outras dúvidas acesse'), colors.yellow.bold('github.com/ServeRest/ServeRest\n'))
+  console.log(colors.cyan.bold('Feito com'), colors.red.bold('♥'), colors.cyan.bold('para todos os QAs e apoiado por'), colors.red.bold(await getRandomFinancialContributor()), '\n')
 })
 server.on('error', onError)
 server.on('listening', onListening)

--- a/src/utils/getRandomFinancialContributor.js
+++ b/src/utils/getRandomFinancialContributor.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const axios = require('axios')
+
+module.exports = async () => {
+  const { data } = await axios.get('https://opencollective.com/serverest/members/all.json')
+  const userArray = removeAdminAndHostUser(data)
+  let arrayNameUsers = getOnlyNameFromAllUsers(userArray)
+  arrayNameUsers = removeDuplicatedValuesFromArray(arrayNameUsers)
+  const randomFinancialContributor = arrayNameUsers[Math.floor(Math.random() * arrayNameUsers.length)]
+  return randomFinancialContributor
+}
+
+const removeAdminAndHostUser = userArray => {
+  return userArray.filter((user) => user.role !== 'ADMIN' && user.role !== 'HOST' && user.name !== 'Paulo Gonçalves')
+}
+
+const getOnlyNameFromAllUsers = userArray => {
+  return Object.keys(userArray).map((key) => userArray[key].name)
+}
+
+const removeDuplicatedValuesFromArray = array => {
+  return [...new Set(array)]
+}


### PR DESCRIPTION
Exibir no terminal, ao iniciar o ServeRest, o nome dos apoiadores financeiros listados em https://opencollective.com/serverest/members/all.json