### PR TITLE
Avoid bad load test on ServeRest - stop Reinaldo

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,7 +29,11 @@ app.use(express.urlencoded({ extended: false }))
 app.use(queryParser())
 app.use(timeout())
 app.use(cors())
-app.use(rateLimiter)
+
+/* istanbul ignore next */
+if (!ehAmbienteDeTestes) {
+  app.use(rateLimiter)
+}
 
 app.disable('etag')
 

--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -5,7 +5,7 @@ const { RateLimiterMemory } = require('rate-limiter-flexible')
 const { aplicacaoExecutandoLocalmente } = require('../utils/ambiente')
 
 const rateLimiter = new RateLimiterMemory({
-  points: 250, // requests
+  points: 30, // requests
   duration: 2 // segundo por IP
 })
 


### PR DESCRIPTION
Reducing rate limit from 7500 req/min to 900
