### PR TITLE
fix(rate-limiter): verificar monitor de forma case insensitive, aumentando compatibilidade e seguindo boas práticas

### DIFF
--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -13,7 +13,8 @@ const rateLimiter = new RateLimiterMemory({
 // 1. Estiver sendo executado em localhost sem o header 'monitor'.
 // 2. Estiver sendo executado fora de localhost.
 module.exports = async (req, res, next) => {
-  const reqContainsHeaderMonitor = req.rawHeaders.includes('monitor')
+  const headerToCheck = 'monitor'
+  const reqContainsHeaderMonitor = req.rawHeaders.some(header => header.toLowerCase() === headerToCheck.toLowerCase())
 
   const messageLoadTest = 'Foi detectado comportamento equivalente a teste de carga'
   const messageAdjust = 'Leia a seção sobre teste de carga https://github.com/ServeRest/ServeRest#teste-de-carga e faça o ajuste necessário.'


### PR DESCRIPTION
fix(rate-limiter): verificar monitor de forma case insensitive, aumentando compatibilidade e seguindo boas práticas

## Description

Eu estava usando alguns métodos do K6, e então percebi que a biblioteca Go que ele usava pegava a key "monitor" e transformava em "Monitor", dando assim probleminhas desenecessários com a ServeRest não reconhecendo o Header monitor como false. 

### How can the user experience this change?

Apenas para testes de performance essa mudança será interessante, o usuário final não terá nenhum ganho direto.

