### PR TITLE
perf: conter OOM contínuo do Cloud Run reduzindo consumo de memória

### DIFF
--- a/.github/workflows/deploy-online-serverest.yml
+++ b/.github/workflows/deploy-online-serverest.yml
@@ -72,31 +72,21 @@ jobs:
       env:
         GCP_IAM_SERVICE_ACCOUNT_KEY: ${{ env.GCP_IAM_SERVICE_ACCOUNT_KEY }}
     - run: gcloud config set project serverest
-    - name: Create flag file used by Gcloud Run Deploy
-      run: |
-        printf "  --update-env-vars:\n    DD_TAGS: git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest" > gcloud-flags.yaml
     - name: Deploy container image to 'staging' environment
       run: |
+        ENV_VARS="^@^ENVIRONMENT=$ENVIRONMENT@DD_SERVICE=$DD_SERVICE@DD_ENV=$ENVIRONMENT@DD_SITE=$DD_SITE"
+        ENV_VARS="$ENV_VARS@DD_API_KEY=$DD_API_KEY@DD_VERSION=${{ github.ref_name }}"
+        ENV_VARS="$ENV_VARS@DD_TAGS=git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest"
+        ENV_VARS="$ENV_VARS@DD_LOGS_INJECTION=true@DD_RUNTIME_METRICS_ENABLED=true@DD_TRACE_HEADER_TAGS=true@DD_LOGS_ENABLED=true"
+        ENV_VARS="$ENV_VARS@DD_PROFILING_ENABLED=false@DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false@DD_APPSEC_ENABLED=false"
+
         gcloud run \
           deploy $SERVICE_STAGING \
           --image gcr.io/$IMAGE_PROJECT_ID/$IMAGE_SERVICE_NAME:${{ github.sha }} \
           --region $REGION \
-          --update-env-vars=ENVIRONMENT=$ENVIRONMENT \
-          --update-env-vars=DD_SERVICE=$DD_SERVICE \
-          --update-env-vars=DD_ENV=$ENVIRONMENT \
-          --update-env-vars=DD_SITE=$DD_SITE \
-          --update-env-vars=DD_API_KEY=$DD_API_KEY \
-          --update-env-vars=DD_VERSION=${{ github.ref_name }} \
-          --flags-file=gcloud-flags.yaml \
-          --update-env-vars=DD_LOGS_INJECTION=true \
-          --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
-          --update-env-vars=DD_TRACE_HEADER_TAGS=true \
-          --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=false \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
-          --update-env-vars=DD_APPSEC_ENABLED=false \
           --concurrency=80 \
-          --timeout=60s
+          --timeout=60s \
+          --update-env-vars="$ENV_VARS"
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: staging.serverest.dev
@@ -174,31 +164,21 @@ jobs:
       env:
         GCP_IAM_SERVICE_ACCOUNT_KEY: ${{ env.GCP_IAM_SERVICE_ACCOUNT_KEY }}
     - run: gcloud config set project serverest
-    - name: Create flag file used by Gcloud Run Deploy
-      run: |
-        printf "  --update-env-vars:\n    DD_TAGS: git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest" > gcloud-flags.yaml
     - name: Deploy container image to 'production' environment
       run: |
+        ENV_VARS="^@^ENVIRONMENT=$ENVIRONMENT@DD_SERVICE=$DD_SERVICE@DD_ENV=$ENVIRONMENT@DD_SITE=$DD_SITE"
+        ENV_VARS="$ENV_VARS@DD_API_KEY=$DD_API_KEY@DD_VERSION=${{ github.ref_name }}"
+        ENV_VARS="$ENV_VARS@DD_TAGS=git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest"
+        ENV_VARS="$ENV_VARS@DD_LOGS_INJECTION=true@DD_RUNTIME_METRICS_ENABLED=true@DD_TRACE_HEADER_TAGS=true@DD_LOGS_ENABLED=true"
+        ENV_VARS="$ENV_VARS@DD_PROFILING_ENABLED=false@DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false@DD_APPSEC_ENABLED=false"
+
         gcloud run \
           deploy $SERVICE_PRODUCTION \
           --image gcr.io/$IMAGE_PROJECT_ID/$IMAGE_SERVICE_NAME:${{ github.sha }} \
           --region $REGION \
-          --update-env-vars=ENVIRONMENT=$ENVIRONMENT \
-          --update-env-vars=DD_SERVICE=$DD_SERVICE \
-          --update-env-vars=DD_ENV=$ENVIRONMENT \
-          --update-env-vars=DD_SITE=$DD_SITE \
-          --update-env-vars=DD_API_KEY=$DD_API_KEY \
-          --update-env-vars=DD_VERSION=${{ github.ref_name }} \
-          --flags-file=gcloud-flags.yaml \
-          --update-env-vars=DD_LOGS_INJECTION=true \
-          --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
-          --update-env-vars=DD_TRACE_HEADER_TAGS=true \
-          --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=false \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
-          --update-env-vars=DD_APPSEC_ENABLED=false \
           --concurrency=80 \
-          --timeout=60s
+          --timeout=60s \
+          --update-env-vars="$ENV_VARS"
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: serverest.dev
@@ -244,31 +224,21 @@ jobs:
       env:
         GCP_IAM_SERVICE_ACCOUNT_KEY: ${{ env.GCP_IAM_SERVICE_ACCOUNT_KEY }}
     - run: gcloud config set project serverest
-    - name: Create flag file used by Gcloud Run Deploy
-      run: |
-        printf "  --update-env-vars:\n    DD_TAGS: git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest" > gcloud-flags.yaml
     - name: Deploy container image to 'compassuol' environment
       run: |
+        ENV_VARS="^@^ENVIRONMENT=$ENVIRONMENT@DD_SERVICE=$DD_SERVICE@DD_ENV=$ENVIRONMENT@DD_SITE=$DD_SITE"
+        ENV_VARS="$ENV_VARS@DD_API_KEY=$DD_API_KEY@DD_VERSION=${{ github.ref_name }}"
+        ENV_VARS="$ENV_VARS@DD_TAGS=git.commit.sha:${{ github.sha }},git.repository_url:github.com/ServeRest/ServeRest"
+        ENV_VARS="$ENV_VARS@DD_LOGS_INJECTION=true@DD_RUNTIME_METRICS_ENABLED=true@DD_TRACE_HEADER_TAGS=true@DD_LOGS_ENABLED=true"
+        ENV_VARS="$ENV_VARS@DD_PROFILING_ENABLED=false@DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false@DD_APPSEC_ENABLED=false"
+
         gcloud run \
           deploy $SERVICE_COMPASSUOL \
           --image gcr.io/$IMAGE_PROJECT_ID/$IMAGE_SERVICE_NAME:${{ github.sha }} \
           --region $REGION \
-          --update-env-vars=ENVIRONMENT=$ENVIRONMENT \
-          --update-env-vars=DD_SERVICE=$DD_SERVICE \
-          --update-env-vars=DD_ENV=$ENVIRONMENT \
-          --update-env-vars=DD_SITE=$DD_SITE \
-          --update-env-vars=DD_API_KEY=$DD_API_KEY \
-          --update-env-vars=DD_VERSION=${{ github.ref_name }} \
-          --flags-file=gcloud-flags.yaml \
-          --update-env-vars=DD_LOGS_INJECTION=true \
-          --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
-          --update-env-vars=DD_TRACE_HEADER_TAGS=true \
-          --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=false \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
-          --update-env-vars=DD_APPSEC_ENABLED=false \
           --concurrency=80 \
-          --timeout=60s
+          --timeout=60s \
+          --update-env-vars="$ENV_VARS"
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: compassuol

--- a/.github/workflows/deploy-online-serverest.yml
+++ b/.github/workflows/deploy-online-serverest.yml
@@ -92,9 +92,11 @@ jobs:
           --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
           --update-env-vars=DD_TRACE_HEADER_TAGS=true \
           --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=true \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=true \
-          --update-env-vars=DD_APPSEC_ENABLED=true
+          --update-env-vars=DD_PROFILING_ENABLED=false \
+          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
+          --update-env-vars=DD_APPSEC_ENABLED=false \
+          --concurrency=80 \
+          --timeout=60s
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: staging.serverest.dev
@@ -192,9 +194,11 @@ jobs:
           --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
           --update-env-vars=DD_TRACE_HEADER_TAGS=true \
           --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=true \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=true \
-          --update-env-vars=DD_APPSEC_ENABLED=true
+          --update-env-vars=DD_PROFILING_ENABLED=false \
+          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
+          --update-env-vars=DD_APPSEC_ENABLED=false \
+          --concurrency=80 \
+          --timeout=60s
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: serverest.dev
@@ -260,9 +264,11 @@ jobs:
           --update-env-vars=DD_RUNTIME_METRICS_ENABLED=true \
           --update-env-vars=DD_TRACE_HEADER_TAGS=true \
           --update-env-vars=DD_LOGS_ENABLED=true \
-          --update-env-vars=DD_PROFILING_ENABLED=true \
-          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=true \
-          --update-env-vars=DD_APPSEC_ENABLED=true
+          --update-env-vars=DD_PROFILING_ENABLED=false \
+          --update-env-vars=DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=false \
+          --update-env-vars=DD_APPSEC_ENABLED=false \
+          --concurrency=80 \
+          --timeout=60s
       env:
         DD_API_KEY: ${{ env.DD_API_KEY }}
         ENVIRONMENT: compassuol


### PR DESCRIPTION
## Description

O container de produção opera há semanas encostado no teto de 256 MiB. Medições feitas via APIs do GCP nos últimos 30 dias:

| Métrica | Valor |
|---|---|
| Memória p99 | 99,9% dos 256 MiB, **todos os dias** |
| CPU p99 | 95,2% |
| Eventos `Memory limit exceeded` | 3.228 em 14 dias (~230/dia) |
| Respostas 5xx | 7.874 de 823.830 requests (0,96%) |

Este PR reduz o consumo dentro do limite atual, sem aumentar custo (o projeto não tem receita e depende do free tier do Cloud Run).

São dois commits: o primeiro faz os ajustes de configuração, o segundo corrige um bug que impedia esses ajustes de terem efeito.

### 1. Ajustes de configuração

**Concorrência de 500 para 80.** Uma única instância de 1 vCPU e 256 MiB autorizava até 500 requests simultâneas no mesmo processo Node. Com o teto em 80, o excedente passa a enfileirar no Cloud Run em vez de derrubar o container. Fila degrada, OOM mata: hoje um kill falha todas as requests em voo e força cold start para quem está atrás.

**Profiling e AppSec do Datadog desligados.** Benchmarks locais no próprio código mostraram que dobram o tempo de CPU por request (`PUT /produtos`: 0,68 ms sem APM, 1,55 ms com profiling e AppSec) e somam cerca de 12 MB ao baseline, num container onde a CPU já opera com p99 de 95%. Tracing, logs, injeção de trace e runtime metrics continuam ligados, então a telemetria do dia a dia não muda.

**Timeout de 300s para 60s.** O app já limita o processamento a 5s via `connect-timeout`, então 300s só prolongava a espera na fila antes do Cloud Run desistir.

### 2. Correção: as env vars não estavam sendo aplicadas

Durante a revisão descobriu-se que o comando repetia `--update-env-vars` catorze vezes, e o gcloud segue a convenção UNIX documentada:

> "Following UNIX convention, if a flag is repeated on the command line, then only the rightmost occurrence takes effect, no diagnostic is emitted."

Ou seja, **apenas a última era aplicada**, silenciosamente. As demais variáveis existiam no serviço só por terem sido enviadas em versões anteriores do workflow, quando cada uma ainda era a última da lista, e por `--update-env-vars` nunca remover o que já está configurado.

Dois efeitos colaterais que isso vinha causando:

- `DD_VERSION` parou de ser atualizada assim que outras linhas foram acrescentadas depois dela
- `DD_TAGS`, montada a cada deploy com o SHA do commit via `--flags-file`, nunca chegava ao serviço, porque o arquivo é expandido na posição em que aparece e havia oito `--update-env-vars` depois dele

Sem esta correção, o desligamento do profiling feito no primeiro commit seria descartado em silêncio, e o profiling continuaria ligado, sendo ele justamente o componente mais caro medido.

Todas as variáveis passam a ser enviadas numa única flag, com o delimitador alternativo `^@^` do gcloud, que permite a vírgula dentro do valor de `DD_TAGS`. O `--flags-file` e o passo que o gerava deixam de ser necessários.

### How can the user experience this change?

Não há mudança de contrato nem de comportamento da API. Nenhuma rota, payload ou código de status muda. O efeito é de infraestrutura e deve aparecer como:

1. Queda no volume de 5xx causados por reciclagem do container
2. Queda na métrica de memória p99 no Cloud Run
3. Redução da latência por request, pela remoção do overhead de profiling e AppSec

Para acompanhar após o deploy, no serviço `app` da região `us-central1`: métricas de utilização de memória, e ausência de novas entradas `Memory limit of 256 MiB exceeded` no Cloud Logging. Vale conferir também que `DD_VERSION` e `DD_TAGS` passaram a refletir o release e o commit atuais, o que valida a correção do item 2.

### Documentation

Não aplicável: a mudança é de configuração de deploy e não altera a documentação da API.

## Related Issues

Nenhuma issue vinculada.

## Notas para quem revisa

A montagem da string de env vars foi simulada localmente com os mesmos valores do workflow, e o parsing resultou nas 14 variáveis esperadas, com as vírgulas de `DD_TAGS` preservadas. O delimitador `@` foi escolhido após conferir que nenhum valor o contém, incluindo a `DD_API_KEY`.

Concorrência e timeout passam a viver no workflow, e não apenas na configuração do serviço, para ficarem versionados e não regredirem num deploy futuro.

Aplicado também ao ambiente `compassuol`, que roda a mesma imagem e tem o mesmo problema.

Fica de fora deste PR, para medir o efeito isolado: aumento de memória para 512Mi e um teto de registros por coleção, que é o que trata a causa raiz do crescimento do dataset ao longo do dia.

Achados pré-existentes levantados durante a investigação, que serão abertos como issues separadas e não são regressões deste PR:

- `trust proxy` não configurado, o que faz `req.ip` resolver para o proxy de ingresso do Cloud Run. Isso provavelmente torna o rate limiter um balde global em vez de por IP, e impede `BLOCKED_IPS` de casar clientes reais
- `connect-timeout` sem `haltOnTimedout`: após 5s o handler continua e escreve em resposta já encerrada
- O `datadog-init` é o ENTRYPOINT do container, então o agente divide os mesmos 256 MiB com o Node e bufferiza cada linha do `morgan`
- O job `common-ci / sonarcloud` falha com `HTTP 403` no `SONAR_TOKEN`, credencial aparentemente expirada, sem relação com este PR

## PR Tasks

- [ ] Has been related to an issue?
- [x] Have tests been added/updated? Não aplicável: mudança de configuração de deploy, sem código de aplicação
- [x] Has Aglio documentation been added/updated? Não aplicável
