### PR TITLE
fix: publicar no npm via trusted publishing em vez de token

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -41,6 +41,13 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    # 'id-token' é exigido pelo trusted publishing do npm, que autentica via OIDC
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+
     steps:
     - name: Project checkout
       uses: actions/checkout@v3
@@ -48,6 +55,9 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 22
+    # O Node 22 embute o npm 10.x e o trusted publishing exige 11.5.1 ou superior
+    - name: Update npm to a version that supports trusted publishing
+      run: npm install -g npm@latest
     - name: Installation of Node.js dependencies
       run: npm ci
     - name: Install 1Password CLI
@@ -63,15 +73,16 @@ jobs:
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         GH_TOKEN: op://CI-CD/GitHub/GH_TOKEN
-        NPM_TOKEN: op://CI-CD/npm/NPM_TOKEN
         DOCKER_REGISTRY_USER: op://CI-CD/docker/username
         DOCKER_REGISTRY_PASSWORD: op://CI-CD/docker/password
         PACT_BROKER_TOKEN: op://CI-CD/pactflow/PACT_BROKER_TOKEN
+    # Sem NPM_TOKEN: o npm detecta o ambiente OIDC e publica via trusted publishing.
+    # A versão vem do package.json, que já traz semantic-release 25 e @semantic-release/npm 13,
+    # as primeiras com suporte a OIDC.
     - name: Release on NPM and Docker
-      run: npx semantic-release@21.0.7
+      run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ env.GH_TOKEN }}
-        NPM_TOKEN: ${{ env.NPM_TOKEN }}
         DOCKER_REGISTRY_USER: ${{ env.DOCKER_REGISTRY_USER }}
         DOCKER_REGISTRY_PASSWORD: ${{ env.DOCKER_REGISTRY_PASSWORD }}
     - run: docker compose build test-contract


### PR DESCRIPTION
## Description

O `NPM_TOKEN` expirou e derrubou o job de release, o que travou o pipeline e impediu que as correções de memória do Cloud Run (#527) chegassem a produção. Em vez de gerar outro token de longa duração, o publish passa a autenticar por OIDC através do trusted publisher já cadastrado no npmjs para este repositório e para o workflow `continuous_delivery.yml`.

Ganho colateral: não existe mais credencial de npm para expirar, vazar ou renovar, e o pacote passa a ser publicado com attestation de proveniência gerada automaticamente.

### O que mudou e por quê

**Pin do semantic-release removido.** O workflow rodava `npx semantic-release@21.0.7`, de 2023, que baixava a versão antiga por cima do que o `npm ci` acabara de instalar. O suporte a OIDC chegou no `@semantic-release/npm` 13, que exige semantic-release 25, e o `package.json` já declara as duas versões (`^25.0.3` e `^13.1.3`). Sem o pin, a versão instalada é a usada.

**Permissão de OIDC no job.** Sem `id-token: write` o GitHub não emite o token e o npm não tem o que validar. Os escopos `contents`, `issues` e `pull-requests` são declarados junto porque, ao declarar `permissions`, todos os não listados vão a zero, e o job perderia capacidades que hoje tem por padrão.

**Atualização do npm.** O trusted publishing exige npm 11.5.1 ou superior. Confirmado na distribuição oficial do Node que o 22.x mais recente ainda embute o npm 10.9.8, então a atualização precisa ser explícita.

**`NPM_TOKEN` removido.** A documentação do npm orienta a não passar o token, porque o CLI detecta o ambiente OIDC sozinho. No nosso caso isso é obrigatório e não opcional: o semantic-release valida o token antes de qualquer outra coisa, e foi exatamente ali que o release morreu com `EINVALIDNPMTOKEN`.

### How can the user experience this change?

Não há mudança no código da aplicação nem no comportamento da API. O efeito é no pipeline de entrega.

Após o merge, o `release` deve publicar o pacote sem nenhum token de npm envolvido. A confirmação de que o trusted publishing está realmente ativo é o selo de proveniência aparecer na página do pacote em https://www.npmjs.com/package/serverest, apontando para este workflow.

Em seguida o encadeamento normal continua: imagem no Docker Hub, tag, release no GitHub e o `deploy-online-serverest`, que finalmente leva as correções do #527 para staging, produção e compassuol.

### Documentation

Não aplicável: mudança de pipeline, sem alteração na documentação da API.

## Related Issues

Related to #529 (a issue automática aberta pelo semantic-release quando o release falhou), que pode ser fechada assim que o release passar.

## Notas para quem revisa

O ponto de maior atenção é o salto de três majors no semantic-release, do 21 para o 25, executando pela primeira vez neste repositório. O `.releaserc.js` foi escrito para a versão 21, mas os plugins declarados no `package.json` já são as versões pareadas com a 25, então a expectativa é de compatibilidade. Ainda assim, é o item a acompanhar no primeiro run.

Os valores cadastrados no trusted publisher do npm precisam bater exatamente com este workflow, e batem: organização `ServeRest`, repositório `ServeRest`, arquivo `continuous_delivery.yml` e environment vazio, já que o job `release` não declara `environment:`.

As demais credenciais do pipeline foram testadas e estão válidas: Docker Hub responde 200, o token do GitHub é válido e o do SonarCloud foi renovado nesta mesma sessão.

## PR Tasks

- [x] Has been related to an issue? Related to #529
- [x] Have tests been added/updated? Não aplicável: mudança de pipeline, sem código de aplicação
- [x] Has Aglio documentation been added/updated? Não aplicável
