### PR TITLE
fix: gerar release notes com o semantic-release 25

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -20,38 +20,29 @@ const transformCommitType = type => {
   return commitTypeMapping[type] || commitTypeMapping.default
 }
 
+// O conventional-changelog-writer entrega o commit dentro de um Proxy imutável e espera
+// de volta apenas um patch, que ele mescla com o commit original. Por isso nada aqui é
+// alterado no objeto recebido: tudo é derivado em cópias novas.
 const customTransform = (commit, context) => {
   const issues = []
 
-  commit.notes.forEach(note => {
-    note.title = 'BREAKING CHANGES'
-  })
+  let subject = commit.subject
 
-  commit.type = transformCommitType(commit.type)
-
-  if (commit.scope === '*') {
-    commit.scope = ''
-  }
-
-  if (typeof commit.hash === 'string') {
-    commit.shortHash = commit.hash.substring(0, 7)
-  }
-
-  if (typeof commit.subject === 'string') {
+  if (typeof subject === 'string') {
     let url = context.repository
       ? `${context.host}/${context.owner}/${context.repository}`
       : context.repoUrl
     if (url) {
       url = `${url}/issues/`
       // Issue URLs.
-      commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
+      subject = subject.replace(/#([0-9]+)/g, (_, issue) => {
         issues.push(issue)
         return `[#${issue}](${url}${issue})`
       })
     }
     if (context.host) {
       // User URLs.
-      commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
+      subject = subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
         if (username.includes('/')) {
           return `@${username}`
         }
@@ -60,15 +51,17 @@ const customTransform = (commit, context) => {
     }
   }
 
-  // remove references that already appear in the subject
-  commit.references = commit.references.filter(reference => {
-    if (issues.indexOf(reference.issue) === -1) {
-      return true
-    }
-    return false
-  })
-
-  return commit
+  return {
+    notes: commit.notes.map(note => ({ ...note, title: 'BREAKING CHANGES' })),
+    type: transformCommitType(commit.type),
+    scope: commit.scope === '*' ? '' : commit.scope,
+    shortHash: typeof commit.hash === 'string' ? commit.hash.substring(0, 7) : commit.shortHash,
+    subject,
+    // remove references that already appear in the subject
+    references: commit.references
+      .filter(reference => issues.indexOf(reference.issue) === -1)
+      .map(reference => ({ ...reference }))
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Description

O trusted publishing configurado em #530 **funcionou**: o log do release mostra `OIDC token exchange with the npm registry succeeded`, o Docker login passou, os commits foram analisados e a versão 3.2.1 foi calculada. O release avançou até a geração das notas e quebrou ali:

```
Failed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
Error: Cannot modify immutable object.
    at customTransform (.releaserc.js:30:15)
```

O `customTransform` foi escrito quando o `conventional-changelog-writer` entregava o commit como objeto comum e aceitava alteração no lugar. A partir da versão 8 ele entrega o commit dentro de um `Proxy` que lança erro em qualquer escrita, e espera de volta apenas um patch, que ele mesmo mescla:

```js
const patch = await transform(preventModifications(commit), ...args)
if (patch) {
  return { ...commit, ...patch, raw: commit }
}
```

A função passa a derivar tudo em cópias novas e a retornar esse patch, sem tocar no objeto recebido. O comportamento externo é idêntico ao anterior.

### Um segundo defeito, este latente

A iteração sobre `notes` tinha o mesmo problema e não apareceu no erro apenas porque nenhum commit desde a última release traz breaking change, o que deixa o array vazio e faz o `forEach` não executar. Ela também foi corrigida, senão voltaria a quebrar no primeiro commit com `BREAKING CHANGE`, provavelmente numa release major e no pior momento possível.

### How can the user experience this change?

Não há mudança no código da aplicação nem na API. O efeito é destravar a geração de release notes e, com ela, o restante do pipeline.

Validei localmente chamando o `transformCommit` do próprio `conventional-changelog-writer` instalado no projeto, com quatro cenários:

| Caso | Resultado |
|---|---|
| Commit simples, o que quebrou no CI | `type` mapeado, `shortHash` gerado |
| Breaking change com `notes` preenchido | título vira `BREAKING CHANGES`, `scope: '*'` vira vazio |
| Issue citada no assunto | vira link e a referência duplicada é removida |
| Menção a usuário | preservada como antes |

Os quatro passam e produzem a mesma saída que a versão anterior produzia.

### Documentation

Não aplicável: configuração de release, sem alteração na API.

## Related Issues

Related to #529, que pode ser fechada quando o release concluir.

## Notas para quem revisa

A mudança é de mutação para construção de patch. Vale conferir que nenhum campo se perdeu na conversão: `notes`, `type`, `scope`, `shortHash`, `subject` e `references` continuam todos sendo produzidos, e os demais campos do commit seguem intactos porque o writer faz o merge com o original.

O `.map(reference => ({ ...reference }))` no final é deliberado: sem ele, os elementos filtrados continuariam sendo proxies imutáveis vazando para o restante do pipeline de geração das notas.

## PR Tasks

- [x] Has been related to an issue? Related to #529
- [x] Have tests been added/updated? Validação executada localmente contra o writer real, descrita acima
- [x] Has Aglio documentation been added/updated? Não aplicável
