### PR TITLE
fix: aplicar rate limit por cliente em vez de global

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,11 @@ if (process.env.BLOCKED_IPS) {
 }
 
 app.set('json spaces', 4)
+// Confia em exatamente um proxy, que é o do Cloud Run. Sem isso req.ip resolve para o
+// endereço do proxy e todos os clientes viram a mesma chave no rate limiter. Com 'true'
+// o Express passaria a ler o primeiro endereço do X-Forwarded-For, que o próprio cliente
+// pode forjar, então o número de saltos precisa ser explícito.
+app.set('trust proxy', 1)
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(queryParser())

--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -10,7 +10,7 @@ const { LOAD_TEST_DETECTED } = require('../utils/constants')
 // para o endereço do proxy do Cloud Run e este limite passaria a valer para todos somados.
 const limitePorIp = new RateLimiterMemory({
   points: 300, // requests
-  duration: 30 // segundo por IP
+  duration: 30 // segundos, por IP
 })
 
 // Limite agregado do container. Existe porque o limite por IP, sozinho, não impõe teto ao
@@ -35,7 +35,7 @@ module.exports = async (req, res, next) => {
     await limiteGlobal.consume('global')
     await limitePorIp.consume(req.ip)
     return next()
-  } catch (limiteAtingido) {
+  } catch (_) {
     return res.status(429).send({
       message: LOAD_TEST_DETECTED
     })

--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -6,9 +6,20 @@ const {
 } = require('../utils/ambiente')
 const { LOAD_TEST_DETECTED } = require('../utils/constants')
 
-const rateLimiter = new RateLimiterMemory({
-  points: 600, // requests
+// Limite por cliente. Depende do 'trust proxy' definido no app.js: sem ele req.ip resolve
+// para o endereço do proxy do Cloud Run e este limite passaria a valer para todos somados.
+const limitePorIp = new RateLimiterMemory({
+  points: 300, // requests
   duration: 30 // segundo por IP
+})
+
+// Limite agregado do container. Existe porque o limite por IP, sozinho, não impõe teto ao
+// total: bastariam vários clientes simultâneos para saturar a instância, que roda com
+// 256 MiB e max-instances 1. Fica acima do limite por IP para que um único cliente abusivo
+// seja barrado pelo próprio limite antes de consumir a cota que protege os demais.
+const limiteGlobal = new RateLimiterMemory({
+  points: 900, // requests
+  duration: 30 // segundos, somando todos os clientes
 })
 
 module.exports = async (req, res, next) => {
@@ -16,11 +27,15 @@ module.exports = async (req, res, next) => {
     return next()
   }
 
-  await rateLimiter.consume(req.ip)
-    .then(() => next())
-    .catch(() => {
-      return res.status(429).send({
-        message: LOAD_TEST_DETECTED
-      })
+  try {
+    await Promise.all([
+      limitePorIp.consume(req.ip),
+      limiteGlobal.consume('global')
+    ])
+    return next()
+  } catch (limiteAtingido) {
+    return res.status(429).send({
+      message: LOAD_TEST_DETECTED
     })
+  }
 }

--- a/src/middlewares/rate-limiter.js
+++ b/src/middlewares/rate-limiter.js
@@ -28,10 +28,12 @@ module.exports = async (req, res, next) => {
   }
 
   try {
-    await Promise.all([
-      limitePorIp.consume(req.ip),
-      limiteGlobal.consume('global')
-    ])
+    // O global vem primeiro de propósito. Avaliar os dois em paralelo faria a requisição
+    // consumir a cota individual mesmo quando o bloqueio viesse do limite agregado, o que
+    // penalizaria clientes inocentes durante congestionamento e, pior, criaria uma chave
+    // por endereço no mapa mesmo para requisições já rejeitadas.
+    await limiteGlobal.consume('global')
+    await limitePorIp.consume(req.ip)
     return next()
   } catch (limiteAtingido) {
     return res.status(429).send({


### PR DESCRIPTION
## Description

Corrige #532.

O `src/middlewares/rate-limiter.js` usa `req.ip` como chave, mas o Express só resolve esse valor a partir do `X-Forwarded-For` quando `trust proxy` está configurado, e não estava. No Cloud Run, onde o container recebe as requisições através do proxy do Google, isso fazia `req.ip` ser sempre o mesmo endereço.

O efeito era que os 600 pontos por 30s, que pareciam ser por IP, funcionavam como **um teto único de 20 req/s compartilhado por todos os usuários**. Um cliente esgotando a cota bloqueava todos os demais até a janela expirar.

### A descoberta que mudou o desenho

A issue propunha `app.set('trust proxy', true)`. **Isso teria criado um buraco de segurança.** Com `true`, o Express lê o endereço mais à esquerda do `X-Forwarded-For`, que é justamente o trecho que o cliente controla, e o rate limit passaria a ser burlável com um header diferente por requisição.

As quatro configurações foram testadas contra três cenários de forja:

| Configuração | Cliente honesto | Cliente forja XFF | Forja múltiplos |
|---|---|---|---|
| Sem `trust proxy` (hoje) | falha | falha | falha |
| `trust proxy: true` | ok | **burlável** | **burlável** |
| **`trust proxy: 1`** | **ok** | **ok** | **ok** |
| `trust proxy: 2` | ok | **burlável** | **burlável** |

Apenas `1` resiste, porque conta um salto a partir do socket e lê o endereço que o proxy do Google anexou, e não o que veio do cliente. Confirmado também em produção que o Cloud Run registra o IP verdadeiro da conexão mesmo quando um `X-Forwarded-For: 1.2.3.4` forjado é enviado.

### Por que entra um segundo limitador

Passar a contar por IP, sozinho, removeria o teto agregado que hoje protege a instância, que roda com 256 MiB e `max-instances 1` e acabou de sair de cerca de 230 OOMs diários (#527).

Por isso entram dois limites: 300 pontos por 30s por cliente e 900 pontos por 30s no total. O global fica acima do individual de propósito, para que um cliente abusivo seja barrado pela própria cota antes de consumir a que protege os demais, que era exatamente o modo de falha descrito na issue.

Para contexto, o pico agregado observado em produção é de cerca de 0,55 req/s, então 30 req/s deixa aproximadamente 54x de margem.

### How can the user experience this change?

Para quem usa o ServeRest de forma normal, o limite deixa de ser afetado pelo comportamento de terceiros. Hoje uma pessoa rodando teste de carga bloqueia todo mundo; a partir daqui ela bloqueia apenas a si mesma.

Validação executada contra o app real, com `ENVIRONMENT=serverest.dev` para ativar o rate limiter como em produção:

| Cenário | Resultado |
|---|---|
| Cliente A consome sua cota | bloqueado em exatamente 300 requests |
| Cliente B após A ser bloqueado | segue passando normalmente |
| Cliente A tenta forjar `X-Forwarded-For` | continua bloqueado, barrado na primeira tentativa |
| Resposta do bloqueio | mantém a mensagem `LOAD_TEST_DETECTED` do app |
| Limite global com IPs novos | dispara em 919 requests somadas, próximo dos 900 |

Suítes do projeto: 12 testes unitários e 125 de integração passando, sem falhas.

### Documentation

Não aplicável: não há mudança de contrato da API. Os códigos de status e as mensagens seguem iguais.

## Related Issues

Fixes #532

## Notas para quem revisa

O valor `1` do `trust proxy` assume um único proxy à frente da aplicação, que é o caso do Cloud Run acessado diretamente, como hoje. Se um load balancer for colocado na frente no futuro, esse número precisa acompanhar, senão o endereço lido volta a ser controlável pelo cliente. Deixei isso registrado em comentário no código.

O `express-ipfilter` também depende de `req.ip`, então a variável `BLOCKED_IPS`, hoje inoperante, volta a funcionar com esta mudança.

Os limites de 300 e 900 foram escolhidos com base no tráfego real medido e podem ser recalibrados sem alterar a estrutura.

## PR Tasks

- [x] Has been related to an issue? Fixes #532
- [x] Have tests been added/updated? Validação executada contra o app real, descrita acima; suítes existentes seguem passando
- [x] Has Aglio documentation been added/updated? Não aplicável
