### PR TITLE
fix: registrar a causa antes de o processo encerrar

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -14,8 +14,38 @@ const { version } = require('../package.json')
 const { formaDeExecucao, urlDocumentacao, aplicacaoExecutandoLocalmente } = require('./utils/ambiente')
 const { conf } = require('./utils/conf')
 const getRandomFinancialContributor = require('./utils/getRandomFinancialContributor')
+const { log } = require('./utils/logger')
 
 const DEFAULT_PORT = 3000
+
+// Erros fora do ciclo de uma requisição encerram o processo sem deixar registro da causa,
+// o que no Cloud Run aparece apenas como um container reiniciando sem explicação.
+/* istanbul ignore next */
+process.on('uncaughtException', erro => {
+  // Responder a uma requisição já encerrada é inofensivo: a resposta chegou ao cliente e o
+  // processo segue íntegro. Derrubar o servidor por isso custaria uma indisponibilidade
+  // inteira para corrigir nada.
+  if (erro.code === 'ERR_HTTP_HEADERS_SENT') {
+    log({ level: 'error', message: `Tentativa de responder requisição já encerrada: ${erro.message}` })
+    return
+  }
+
+  encerrar(`Exceção não capturada: ${erro.message}. Stack: ${erro.stack}`)
+})
+
+/* istanbul ignore next */
+process.on('unhandledRejection', motivo => {
+  encerrar(`Promise rejeitada sem tratamento: ${motivo instanceof Error ? motivo.stack : motivo}`)
+})
+
+// Sai de imediato em vez de drenar as conexões abertas. Com max-instances 1 no Cloud Run
+// não existe outra instância para atender quem chegar durante a drenagem, então esperar
+// só adiaria a subida do container substituto e prolongaria a indisponibilidade.
+/* istanbul ignore next */
+function encerrar (mensagem) {
+  log({ level: 'error', message: mensagem })
+  process.exit(1)
+}
 
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,9 @@ require('dotenv').config({ path: path.resolve(__dirname, '../.env'), quiet: true
 
 const colors = require('colors')
 const debug = require('debug')('nodestr:server')
+const fs = require('fs')
 const http = require('http')
+const util = require('util')
 const open = require('open').default
 
 const { version } = require('../package.json')
@@ -21,7 +23,12 @@ const DEFAULT_PORT = 3000
 // Erros fora do ciclo de uma requisição encerram o processo sem deixar registro da causa,
 // o que no Cloud Run aparece apenas como um container reiniciando sem explicação.
 /* istanbul ignore next */
-process.on('uncaughtException', erro => {
+process.on('uncaughtException', valor => {
+  // Node permite lançar qualquer valor, não só Error. Sem esta normalização, um throw de
+  // string ou null faria o próprio handler lançar ao acessar .code, perdendo o registro
+  // da causa, que é justamente o que estes handlers existem para garantir.
+  const erro = valor instanceof Error ? valor : new Error(util.inspect(valor))
+
   // Responder a uma requisição já encerrada é inofensivo: a resposta chegou ao cliente e o
   // processo segue íntegro. Derrubar o servidor por isso custaria uma indisponibilidade
   // inteira para corrigir nada.
@@ -35,7 +42,7 @@ process.on('uncaughtException', erro => {
 
 /* istanbul ignore next */
 process.on('unhandledRejection', motivo => {
-  encerrar(`Promise rejeitada sem tratamento: ${motivo instanceof Error ? motivo.stack : motivo}`)
+  encerrar(`Promise rejeitada sem tratamento: ${motivo instanceof Error ? motivo.stack : util.inspect(motivo)}`)
 })
 
 // Sai de imediato em vez de drenar as conexões abertas. Com max-instances 1 no Cloud Run
@@ -43,6 +50,10 @@ process.on('unhandledRejection', motivo => {
 // só adiaria a subida do container substituto e prolongaria a indisponibilidade.
 /* istanbul ignore next */
 function encerrar (mensagem) {
+  // console.log é assíncrono quando stdout é um pipe, caso do Cloud Run, e process.exit
+  // não drena writes pendentes. A escrita síncrona no stderr garante que a causa fique
+  // registrada mesmo que o log estruturado seja truncado pelo encerramento.
+  fs.writeSync(2, `${mensagem}\n`)
   log({ level: 'error', message: mensagem })
   process.exit(1)
 }


### PR DESCRIPTION
## Description

Corrige #533, com o escopo ajustado depois que a investigação corrigiu a premissa da issue (detalhado abaixo).

Erros fora do ciclo de uma requisição encerravam o processo **sem deixar registro da causa**. No Cloud Run isso aparecia apenas como um container reiniciando sem explicação, e a informação se perdia justamente quando era mais necessária.

Agora a exceção é registrada com stack antes do encerramento, tanto para exceções não capturadas quanto para promises rejeitadas sem tratamento.

**Quando o processo encerra não muda.** Ele já encerrava nos dois casos e continua encerrando. O que muda é passar a saber por quê.

### A correção da análise que motivou a issue

A #533 afirma que o `ERR_HTTP_HEADERS_SENT` derrubaria o processo. **Isso está errado**, e o teste comparativo mostra por quê:

```
express-async-errors ATIVO   -> virou uncaughtException? NAO
express-async-errors AUSENTE -> virou uncaughtException? SIM
```

O ServeRest carrega o `express-async-errors` na linha 3 do `app.js`, e ele intercepta esse erro nos handlers async. Reproduzi o cenário completo contra o app real: o erro acontece, é registrado, e o servidor continua respondendo 200 normalmente.

A issue foi escrita a partir de uma reprodução num app isolado, sem esse pacote, e o resultado foi generalizado sem verificar a diferença. Vou comentar isso na issue.

O que sobra é a lacuna real, que a investigação expôs: não havia nenhuma rede de proteção nem registro para erros fora do ciclo de requisição.

### Duas decisões de comportamento

**Responder a uma requisição já encerrada não derruba o servidor.** É inofensivo: a resposta chegou ao cliente e o processo segue íntegro. Derrubar por isso custaria uma indisponibilidade inteira para corrigir nada.

**O encerramento é imediato, sem drenar conexões.** Chegamos aqui descartando o graceful shutdown: com `max-instances: 1` não existe outra instância para atender quem chega durante a drenagem, então esperar apenas adiaria a subida do container substituto e prolongaria a indisponibilidade. Com o tráfego atual, de cerca de 0,5 req/s e latência de poucos milissegundos, a concorrência em voo fica na casa de 0,001 requisição, ou seja, quase nunca há o que preservar.

### How can the user experience this change?

Nenhuma mudança de contrato, de rota ou de comportamento visível na API.

O efeito aparece na operação: quando o container reiniciar por um erro inesperado, o Cloud Logging passará a conter a exceção e o stack que causaram o reinício.

Validação executada contra o servidor real:

| Cenário | Esperado | Resultado |
|---|---|---|
| `ERR_HTTP_HEADERS_SENT` | registra e continua | processo sobreviveu, mensagem registrada |
| Exceção genérica | registra e sai com 1 | `exit=1`, com stack no log |
| Promise rejeitada sem catch | registra e sai com 1 | `exit=1`, com stack no log |

Suítes do projeto: 12 unitários e 125 de integração passando.

### Documentation

Não aplicável: não altera a API.

## Related Issues

Fixes #533

## Notas para quem revisa

Os handlers ficam no `server.js`, e não no `app.js`, de propósito: são proteção do processo, e os testes carregam o `app.js` diretamente, então as suítes não sofrem interferência de handlers globais.

O `unhandledRejection` merece atenção na revisão. Registrar um handler para ele alteraria o padrão do Node, que hoje é encerrar. Como o handler aqui também encerra, o comportamento fica idêntico ao atual e o ganho é apenas o registro. Se em algum momento fizer sentido tornar o serviço tolerante a promises soltas, isso deve ser uma decisão consciente e medida à parte, não um efeito colateral deste PR.

## PR Tasks

- [x] Has been related to an issue? Fixes #533
- [x] Have tests been added/updated? Validação executada contra o servidor real, descrita acima; suítes existentes seguem passando
- [x] Has Aglio documentation been added/updated? Não aplicável
